### PR TITLE
PROD-2926: Giltab CI/CD Template

### DIFF
--- a/.github/workflows/gitlab-ci-lint.yml
+++ b/.github/workflows/gitlab-ci-lint.yml
@@ -2,9 +2,15 @@ name: Enable Gitlab CI Lint
 on: push
 
 jobs:
-  insert:
+  validate:
     runs-on: ubuntu-latest
     steps:
-      - name: noop
-        run: |
-          echo noop
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: set current branch template
+        run: sed -i "s/main/${GITHUB_REF##*/}/" example-gitlab-ci.yml
+      - name: validate template
+        run: ./gitlab-ci-lint.sh example-gitlab-ci.yml
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_CI_JOB_TOKEN }}
+          GITLAB_PROJECT_ID: ${{ secrets.GITLAB_CI_PROJECT_ID }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We recommend adding `environment` to help us help you differentiate multiple dep
 ```yaml
 
 include:
-  - remote: 'https://raw.githubusercontent.com/cto-ai/gitlab-template/v1.0/cto.gitlab-ci.yml'
+  - remote: 'https://raw.githubusercontent.com/cto-ai/events-gitlab-template/v1.0/cto.gitlab-ci.yml'
 
 
 deploy_success:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# gitlab-template
+# CTO.ai Gitlab CI/CD Template
+
+This Gitlab template allows you to extend the insights data received by CTO.ai. You can add data to you workflows for deployment tools that are not configured with Gitlab's deployment API.
+
+## Required Inputs
+
+### `TOKEN`
+CTO.ai api token, follow [these docs to generate](https://cto.ai/docs/integrate-any-tool)
+
+### `TEAM_ID`
+CTO.ai team ID sending the data, follow [these docs to access](https://cto.ai/docs/integrate-any-tool)
+
+### `EVENT_NAME`
+
+Name of event being sent i.e. "deployment"
+
+### `EVENT_ACTION`
+
+Action associated with event i.e. "failure", "progressing", "blocked" or "success"
+
+## Recommendations
+
+Define 2 new secrets for your `TOKEN` and `TOKEN` to be passed into the action.
+
+1. From your GitHub repo, click Settings -> CI/CD -> Variables
+2. Create `CTOAI_TEAM_ID` variable using your CTO.ai-issued Team Id. Mask and protect the variable.
+3. Create `CTOAI_EVENTS_API_TOKEN` variable using your CTO.ai-issued API Token. Mask and protect the variable.
+
+## Example Usage
+
+If you have a Gitlab pipeline that deploys your application (i.e. serverless, npm publish, Azure, etc), you can drop this job in right after that step to capture the success or fail of that deployment. You can use [rules](https://docs.gitlab.com/ee/ci/yaml/#rules) to control when to execute `success` or `failure`
+
+We recommend adding `environment` to help us help you differentiate multiple deployment events from the same repository to different environments or workflows. This will be reflected on your Insights Dashboard.
+
+```yaml
+
+include:
+  - remote: 'https://raw.githubusercontent.com/cto-ai/gitlab-template/v1.0/cto.gitlab-ci.yml'
+
+
+deploy_success:
+  stage: cto_event
+  variables:
+    TEAM_ID: "${CTOAI_TEAM_ID}"
+    TOKEN: "${CTOAI_EVENTS_API_TOKEN}"
+    EVENT_NAME: "deployment"
+    EVENT_ACTION: "success"
+  when: on_success # Trigger if all jobs in pipeline were successful
+  environment:
+    name: production
+  extends:
+    - .cto-notify-event
+
+deploy_failure:
+  stage: cto_event
+  variables:
+    TEAM_ID: "${CTOAI_TEAM_ID}"
+    TOKEN: "${CTOAI_EVENTS_API_TOKEN}"
+    EVENT_NAME: "deployment"
+    EVENT_ACTION: "failure"
+  when: on_failure # Trigger if any of jobs in pipeline failed. job with `allow_failure` will not be considered failed job even in failure.
+  environment:
+    name: production
+  extends:
+    - .cto-notify-event
+
+stages:
+  # Previous Jobs
+  - cto_event
+```

--- a/example-gitlab-ci.yml
+++ b/example-gitlab-ci.yml
@@ -1,0 +1,37 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/cto-ai/gitlab-template/main/template.yml'
+
+deploy:
+  stage: deploy
+  script:
+    - echo "Deployment Done!"
+
+deploy_success:
+  stage: cto_event
+  variables:
+    TEAM_ID: "${CTOAI_TEAM_ID}"
+    TOKEN: "${CTOAI_EVENTS_API_TOKEN}"
+    EVENT_NAME: "deployment"
+    EVENT_ACTION: "success"
+  when: on_success # Trigger if all jobs in pipeline were successful
+  environment:
+    name: production
+  extends:
+    - .cto-notify-event
+
+deploy_failure:
+  stage: cto_event
+  variables:
+    TEAM_ID: "${CTOAI_TEAM_ID}"
+    TOKEN: "${CTOAI_EVENTS_API_TOKEN}"
+    EVENT_NAME: "deployment"
+    EVENT_ACTION: "failure"
+  when: on_failure # Trigger if any of jobs in pipeline failed. job with `allow_failure` will not be considered failed job even in failure.
+  environment:
+    name: production
+  extends:
+    - .cto-notify-event
+
+stages:
+  - deploy
+  - cto_event

--- a/example-gitlab-ci.yml
+++ b/example-gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://raw.githubusercontent.com/cto-ai/gitlab-template/main/template.yml'
+  - remote: 'https://raw.githubusercontent.com/cto-ai/events-gitlab-template/main/template.yml'
 
 deploy:
   stage: deploy

--- a/gitlab-ci-lint.sh
+++ b/gitlab-ci-lint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+GITLAB_API_URL=${2:-${GITLAB_API_URL:-"https://gitlab.com/api/v4"}}
+GITLAB_TOKEN=${3:-${GITLAB_TOKEN}}
+GITLAB_PROJECT_ID=${4:-${GITLAB_PROJECT_ID}}
+
+INPUT=$(cat "$1")
+
+RESPONSE=$(
+  jq --null-input --arg yaml "$INPUT" '.content=$yaml' \
+   | curl -s "${GITLAB_API_URL}/projects/${GITLAB_PROJECT_ID}/ci/lint" \
+      --header 'Content-Type: application/json' \
+      --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+      --data @-
+)
+
+echo "$RESPONSE"
+
+STATUS=$(echo "$RESPONSE" | jq -r '.valid')
+
+if [[ $STATUS == 'true' ]]; then
+    exit 0
+elif [[ $STATUS == 'false' ]]; then
+    exit 1
+else
+    exit 2
+fi

--- a/template.yml
+++ b/template.yml
@@ -1,0 +1,24 @@
+variables:
+  ENDPOINT: https://events.cto.ai/
+
+
+.cto-send-event: &cto-send-event
+    - | 
+       curl --location --request POST "${ENDPOINT}" \
+            --header "`echo 'Authorization: Bearer' ${TOKEN}`" \
+            --header 'Content-Type: application/json' \
+            --header 'x-ops-mechanism: gitlab-job' \
+            --data "{
+              \"repo\":\"${CI_PROJECT_PATH}\",
+              \"branch\":\"${CI_COMMIT_BRANCH}\",
+              \"commit\":\"${CI_COMMIT_SHA}\",
+              \"environment\":\"${CI_ENVIRONMENT_NAME}\",
+              \"event_name\":\"${EVENT_NAME}\",
+              \"event_action\":\"${EVENT_ACTION}\",
+              \"team_id\":\"${TEAM_ID}\",
+              \"meta\":{\"user\":\"${GITLAB_USER_LOGIN}\"}
+            }"
+
+.cto-notify-event:
+  script:
+    - *cto-send-event


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitish@cto.ai>

We are setting up Gitlab templates to standardize the process, how users can send events to CTO platform. We have included example in README, how users can add the template in their own pipeline.

Additionally, we are using Gitlab APIs to validate the template with the help of sample pipeline i.e. `example-gitlab-ci.yml`

**Note: Users are recommended to use `template.yml` from tagged version. `main` branch can have breaking changes **